### PR TITLE
Feature/add more tests (#24)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+    branches: [main, develop, '**']
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-26, macos-15, macos-14]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Run tests
+        run: make test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,282 @@
+# AGENTS.md — app-menu
+
+**Repository**: https://github.com/barseghyanartur/app-menu  
+**Maintainer**: Artur Barseghyan <artur.barseghyan@gmail.com>
+
+---
+
+## 1. Project mission
+
+> A lightweight macOS menu-bar application that surfaces installed
+> applications — grouped by their App Store category — via a system status-bar
+> menu, with no external dependencies beyond the macOS SDK.
+
+Key constraints that must never be violated:
+
+- **No third-party dependencies.** The app uses only Apple frameworks
+  (`AppKit`, `SwiftUI`, `Foundation`).
+- **Sandbox-compatible.** All filesystem access must go through the
+  security-scoped bookmark API (`DirectoryAccess`). Never bypass the sandbox.
+- **Swift 5 / macOS 13.1+.** Do not use APIs that require a higher deployment
+  target without gating with `#available`.
+- **No network access at runtime.** The app never makes outbound requests.
+
+---
+
+## 2. Repository layout
+
+```text
+ApplicationMenu/
+    ApplicationMenuApp.swift        # @main entry point, AppDelegate, all views,
+                                    # DirectoryAccess, URL.userHome extension
+    ContentView.swift               # Unused SwiftUI placeholder (not surfaced in UI)
+    SettingsWindowController.swift  # Dead code — legacy NIB-based controller,
+                                    # superseded by the SwiftUI SettingsView in
+                                    # ApplicationMenuApp.swift. Do not delete yet;
+                                    # see §6.
+    Info.plist                      # Injects $(MARKETING_VERSION) as AppVersion
+    ApplicationMenu.entitlements    # App Sandbox + user-selected read-only files
+    Assets.xcassets/                # App icon (tabler icons, MIT licensed)
+
+ApplicationMenuTests/
+    ApplicationMenuTests.swift      # Unit tests (XCTest, @testable import)
+
+ApplicationMenuUITests/
+    ApplicationMenuUITests.swift        # Basic launch + state assertion
+    ApplicationMenuUITestsLaunchTests.swift  # Screenshot on launch
+
+ApplicationMenu.xcodeproj/          # Xcode project; do not hand-edit
+CHANGELOG.rst
+README.rst
+TESTING.md                          # Test running guide
+```
+
+The entire application logic lives in **`ApplicationMenuApp.swift`**.  There is
+no separate model layer, no persistence layer beyond `UserDefaults`, and no
+networking.
+
+---
+
+## 3. Architecture
+
+### 3.1 Class / struct map
+
+| Symbol | Kind | Responsibility |
+|---|---|---|
+| `URL.userHome` / `URL.userHomePath` | Extension | Resolves `~` via `getpwuid` (sandbox-safe) |
+| `DirectoryAccess` | Class (static methods) | Security-scoped bookmark lifecycle |
+| `AppDelegate` | `NSObject, NSApplicationDelegate` | Status bar item, menu population, window management |
+| `SettingsView` | SwiftUI `View` | Tab container for the three settings panes |
+| `AppearanceSettingsView` | SwiftUI `View` | Radio group: Text / Icon / Text & Icon |
+| `AppsMenuSettingsView` | SwiftUI `View` | Toggle: case-insensitive sorting |
+| `DirectoryAccessView` | SwiftUI `View` | Grant / retract `~/Applications` access |
+| `ChromeAppsSettingsView` | SwiftUI `View` | Toggle: show browser web-apps |
+| `AboutView` | SwiftUI `View` | Tab container: License, Credits, Version |
+| `LicenseView` / `CreditsView` / `VersionView` | SwiftUI `View` | Static info panes |
+
+### 3.2 Menu population flow
+
+```text
+applicationDidFinishLaunching
+  └─ DirectoryAccess.restoreAccess()   # re-hydrate security-scoped bookmark
+  └─ populateMenu()
+       ├─ scan /Applications, /System/Applications, ~/Applications
+       │    └─ fetchAppDetails(atPath:)
+       │         ├─ read Info.plist → CFBundleName / LSApplicationCategoryType
+       │         ├─ load .icns icon
+       │         └─ fallback: filename → makeHumanReadableFromFilename
+       ├─ group apps by makeHumanReadable(LSApplicationCategoryType)
+       ├─ sort each group (case-sensitive or -insensitive per UserDefaults)
+       ├─ [optional] Chrome/Brave/Edge/Opera/Vivaldi apps submenu
+       ├─ "All" flat submenu
+       └─ Separator → Refresh / Settings / About / Quit
+```
+
+### 3.3 UserDefaults keys
+
+| Key | Type | Default | Used by |
+|---|---|---|---|
+| `menuBarOption` | `Int` | `0` | `AppDelegate.configureMenuBarItem()` — 0=Text, 1=Icon, 2=Text+Icon |
+| `caseInsensitiveAppsSorting` | `Bool` | `false` | Sort comparator in `populateMenu()` |
+| `showChromeApps` | `Bool` | `false` | Chrome-apps submenu block in `populateMenu()` |
+| `userSelectedDirectory` | `Data` | absent | Security-scoped bookmark for `~/Applications` |
+| `listAppsFromSubDirsRecursively` | `Bool` | `false` | **Not yet active** — toggled UI is commented out |
+
+### 3.4 Notification
+
+`NSNotification.Name("MenuOptionChanged")` is posted by `SettingsView.saveSettings()`
+and observed by `AppDelegate` to trigger `configureMenuBarItem()` without a full
+menu rebuild.
+
+---
+
+## 4. Key behaviours and invariants
+
+1. **`DirectoryAccess.restoreAccess()` returns `nil` when no bookmark exists** —
+   callers must handle this gracefully (`populateMenu()` is called either way).
+2. **`fetchAppDetails` never returns a `nil` icon** — it falls back to
+   `NSWorkspace.shared.icon(forFile:)`.
+3. **`makeHumanReadable` returns the empty string for an empty input** — callers
+   should not assume a non-empty result.
+4. **`resizeImage` always returns a new `NSImage`** — the original is not mutated.
+5. **`SettingsWindowController.swift` is dead code.** It declares a second
+   `AppDelegate` class that will cause a compile error if the file is included in
+   the active target. It is currently excluded from compilation. Do not re-include
+   it without first removing or renaming the duplicate `AppDelegate`.
+
+---
+
+## 5. Build, test, and release
+
+All common operations are wrapped in `make` targets.  Run `make help` for a
+full list.  The raw `xcodebuild` commands are shown below for reference; prefer
+the `make` equivalents in practice.
+
+### Common make targets
+
+| Command | What it does |
+|---|---|
+| `make build` | Compile Debug build (smoke-check) |
+| `make test` | Run unit + UI tests |
+| `make test-unit` | Run unit tests only (faster) |
+| `make release` | Full release pipeline — see §5 "Release" below |
+| `make bump V=0.2.0` | Update `MARKETING_VERSION` in the project file |
+| `make clean` | Remove all generated artefacts under `Releases/` |
+
+### Build (Xcode UI)
+
+Open `ApplicationMenu.xcodeproj`, select the `ApplicationMenu` scheme, press
+**⌘B**.
+
+### Build (command line)
+
+```sh
+make build
+# or directly:
+xcodebuild build \
+  -project ApplicationMenu.xcodeproj \
+  -scheme ApplicationMenu \
+  -destination 'platform=macOS' \
+  CODE_SIGN_IDENTITY="-"
+```
+
+### Run unit tests
+
+```sh
+make test        # unit + UI
+make test-unit   # unit only
+# or in Xcode: ⌘U
+```
+
+See `TESTING.md` for a full description of each test class.
+
+### Release
+
+```sh
+make release
+```
+
+This runs the full pipeline in order:
+
+1. `make archive` — `xcodebuild archive` → `Releases/archive/ApplicationMenu.xcarchive`
+2. `make export`  — `xcodebuild -exportArchive` (Copy App method) → `Releases/export/ApplicationMenu.app`
+3. `make dmg`     — stages `.app` + `/Applications` symlink, calls `hdiutil` → `Releases/dist/ApplicationMenu.dmg`
+4. `make zip`     — `ditto -ck` → `Releases/dist/ApplicationMenu.zip`
+5. `make checksum`— `shasum -a 256` → printed to stdout and saved to `Releases/dist/ApplicationMenu.zip.sha256`
+
+At the end, the Makefile prints the SHA-256 and the three manual steps that
+remain (git tag, GitHub release upload, tap formula update).
+
+### Deployment target
+
+`MACOSX_DEPLOYMENT_TARGET = 13.1` (macOS Ventura).  Any new API call that
+requires 14+ must be wrapped in `if #available(macOS 14, *) { ... }`.
+
+### GitHub CI
+
+Tests run automatically on every push and pull request via `.github/workflows/test.yml`.
+
+| Runner | Status |
+|--------|--------|
+| macOS 26 (Tahoe) | Tested |
+| macOS 15 (Sequoia) | Tested |
+| macOS 14 (Sonoma) | Tested |
+| macOS 13 (Ventura) | Not tested — runner deprecated on GitHub |
+
+macOS 13 (Ventura) remains fully supported and works correctly; it is not tested
+on CI because GitHub no longer provides macOS 13 runners. The app's deployment
+target is 13.1, ensuring compatibility.
+
+---
+
+## 6. Known issues / tech debt
+
+These are documented so that an agent does not "fix" them in a way that
+introduces new problems.
+
+| Issue | Location | Notes |
+|---|---|---|
+| `SettingsWindowController.swift` contains a duplicate `AppDelegate` | `SettingsWindowController.swift` | File is excluded from the compile target. The correct fix is to delete the file entirely after verifying nothing references it. |
+| `ContentView.swift` is unused | `ContentView.swift` | The app is menu-bar only; `ContentView` is never presented. It is safe to delete. |
+| `listAppsFromSubDirsRecursively` setting is wired up in `UserDefaults` but the corresponding scan logic is commented out | `ApplicationMenuApp.swift` | Implement recursive directory traversal or remove the key entirely. |
+| `SettingsView` holds window state in a local `@State var settingsWindow` instead of using `WindowGroup` or a dedicated controller | `AppDelegate` | Works but leaks if the user dismisses the window via the OS close button — `settingsWindow` is not set back to `nil`. |
+
+---
+
+## 7. Workflow for common tasks
+
+### Adding a new settings toggle
+
+1. Add a new `@AppStorage`-backed `Bool` key to the appropriate `*SettingsView`.
+2. Document the key in the **UserDefaults keys** table in §3.3 of this file.
+3. Read the key in `populateMenu()` or `configureMenuBarItem()`.
+4. Add a `UserDefaultsSettingsTests` test asserting the default value.
+
+### Adding a new app directory to scan
+
+1. Append the path to the `appDirectories` array in `AppDelegate.populateMenu()`.
+2. If the directory requires a separate security-scoped bookmark, extend
+   `DirectoryAccess` — do not add a second `UserDefaults` key for the same
+   purpose.
+3. Add an integration note to `CHANGELOG.rst`.
+
+### Adding a new browser web-app directory
+
+Append the path string to the `chromeAppsDirs` array in `populateMenu()`.
+No other changes are required.
+
+### Changing the menu-bar display modes
+
+All three modes (text / icon / text+icon) are handled in the `switch` in
+`AppDelegate.configureMenuBarItem()`.  The integer values **must** stay in sync
+with the `Picker` tag values in `AppearanceSettingsView`:
+0 = Text, 1 = Icon, 2 = Text & Icon.
+
+---
+
+## 8. Coding conventions
+
+- **Swift 5**, SwiftUI where practical, AppKit where unavoidable.
+- **No force-unwraps** on values that can legitimately be absent at runtime
+  (bookmark data, plist values, icon files). Use `guard let` / `if let`.
+- **`@objc` selectors** are required on any method passed to `addObserver` or
+  used as a menu-item action.
+- **`NSImage` manipulation** must happen on the main thread; `resizeImage` uses
+  `lockFocus` / `unlockFocus`, which is not thread-safe.
+- Comment style: use `// TODO:` for known incomplete paths, not `//FIXME` or
+  silent omissions.
+- `MARKETING_VERSION` in `project.pbxproj` is the single source of truth for
+  the version string; it is injected into `Info.plist` as `AppVersion`.
+
+---
+
+## 9. Forbidden
+
+- Do not add any dependency that requires a `Package.swift` or CocoaPods
+  `Podfile`.
+- Do not raise the deployment target above `13.1` without updating
+  `README.rst` compatibility matrix and `CHANGELOG.rst`.
+- Do not store user data outside `UserDefaults` and security-scoped bookmarks.
+- Do not add outbound network calls to the main application target.
+- Do not hand-edit `ApplicationMenu.xcodeproj/project.pbxproj`; use Xcode's
+  project editor or `xcodebuild` settings.

--- a/ApplicationMenu.xcodeproj/project.pbxproj
+++ b/ApplicationMenu.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.delusionalinsanity.ApplicationMenu;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -479,7 +479,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.delusionalinsanity.ApplicationMenu;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -499,7 +499,7 @@
 				DEVELOPMENT_TEAM = LQ3AR8MSBY;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.1;
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.delusionalinsanity.ApplicationMenuTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -519,7 +519,7 @@
 				DEVELOPMENT_TEAM = LQ3AR8MSBY;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.1;
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.delusionalinsanity.ApplicationMenuTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -537,7 +537,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LQ3AR8MSBY;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.delusionalinsanity.ApplicationMenuUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -555,7 +555,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = LQ3AR8MSBY;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.delusionalinsanity.ApplicationMenuUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/ApplicationMenuTests/ApplicationMenuTests.swift
+++ b/ApplicationMenuTests/ApplicationMenuTests.swift
@@ -8,29 +8,601 @@
 import XCTest
 @testable import ApplicationMenu
 
-final class ApplicationMenuTests: XCTestCase {
+// MARK: - makeHumanReadable Tests
+
+final class MakeHumanReadableTests: XCTestCase {
+
+    var delegate: AppDelegate!
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        delegate = AppDelegate()
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        delegate = nil
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    // MARK: Standard category strings
+
+    func testStandardCategoryString() {
+        // "public.app-category.utilities" → "Utilities"
+        XCTAssertEqual(delegate.makeHumanReadable("public.app-category.utilities"), "Utilities")
     }
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    func testCategoryWithHyphen() {
+        // "public.app-category.developer-tools" → "Developer Tools"
+        XCTAssertEqual(delegate.makeHumanReadable("public.app-category.developer-tools"), "Developer Tools")
+    }
+
+    func testCategoryWithMultipleHyphens() {
+        XCTAssertEqual(
+            delegate.makeHumanReadable("public.app-category.graphics-design"),
+            "Graphics Design"
+        )
+    }
+
+    func testCategoryMusic() {
+        XCTAssertEqual(delegate.makeHumanReadable("public.app-category.music"), "Music")
+    }
+
+    func testCategoryProductivity() {
+        XCTAssertEqual(delegate.makeHumanReadable("public.app-category.productivity"), "Productivity")
+    }
+
+    func testCategoryEducation() {
+        XCTAssertEqual(delegate.makeHumanReadable("public.app-category.education"), "Education")
+    }
+
+    func testCategoryGames() {
+        XCTAssertEqual(delegate.makeHumanReadable("public.app-category.games"), "Games")
+    }
+
+    // MARK: Edge cases
+
+    func testEmptyString() {
+        XCTAssertEqual(delegate.makeHumanReadable(""), "")
+    }
+
+    func testNoDots() {
+        XCTAssertEqual(delegate.makeHumanReadable("utilities"), "Utilities")
+    }
+
+    func testSingleDot() {
+        XCTAssertEqual(delegate.makeHumanReadable("a.utilities"), "Utilities")
+    }
+
+    func testAlreadyCapitalized() {
+        XCTAssertEqual(delegate.makeHumanReadable("public.app-category.Utilities"), "Utilities")
+    }
+
+    func testLowercaseInput() {
+        XCTAssertEqual(delegate.makeHumanReadable("com.apple.games"), "Games")
+    }
+
+    func testUppercaseInput() {
+        XCTAssertEqual(delegate.makeHumanReadable("COM.APPLE.GAMES"), "Games")
+    }
+
+    func testOtherFallbackCategory() {
+        XCTAssertEqual(delegate.makeHumanReadable("Other"), "Other")
+    }
+
+    func testCategoryNewsstand() {
+        XCTAssertEqual(delegate.makeHumanReadable("public.app-category.newsstand"), "Newsstand")
+    }
+
+    func testCategoryHealthcareFitness() {
+        XCTAssertEqual(
+            delegate.makeHumanReadable("public.app-category.healthcare-fitness"),
+            "Healthcare Fitness"
+        )
+    }
+}
+
+// MARK: - makeHumanReadableFromFilename Tests
+
+final class MakeHumanReadableFromFilenameTests: XCTestCase {
+
+    var delegate: AppDelegate!
+
+    override func setUpWithError() throws {
+        delegate = AppDelegate()
+    }
+
+    override func tearDownWithError() throws {
+        delegate = nil
+    }
+
+    func testSimpleFilename() {
+        XCTAssertEqual(delegate.makeHumanReadableFromFilename("safari"), "Safari")
+    }
+
+    func testHyphenSeparated() {
+        XCTAssertEqual(delegate.makeHumanReadableFromFilename("google-chrome"), "Google Chrome")
+    }
+
+    func testUnderscoreSeparated() {
+        XCTAssertEqual(delegate.makeHumanReadableFromFilename("visual_studio"), "Visual Studio")
+    }
+
+    func testMixedSeparators() {
+        XCTAssertEqual(delegate.makeHumanReadableFromFilename("my-cool_app"), "My Cool App")
+    }
+
+    func testAlreadyCapitalized() {
+        XCTAssertEqual(delegate.makeHumanReadableFromFilename("Safari"), "Safari")
+    }
+
+    func testMultipleHyphens() {
+        XCTAssertEqual(
+            delegate.makeHumanReadableFromFilename("some-app-name"),
+            "Some App Name"
+        )
+    }
+
+    func testSingleWord() {
+        XCTAssertEqual(delegate.makeHumanReadableFromFilename("mail"), "Mail")
+    }
+
+    func testEmptyString() {
+        XCTAssertEqual(delegate.makeHumanReadableFromFilename(""), "")
+    }
+
+    func testNoSeparators() {
+        XCTAssertEqual(delegate.makeHumanReadableFromFilename("xcode"), "Xcode")
+    }
+}
+
+// MARK: - resizeImage Tests
+
+final class ResizeImageTests: XCTestCase {
+
+    var delegate: AppDelegate!
+
+    override func setUpWithError() throws {
+        delegate = AppDelegate()
+    }
+
+    override func tearDownWithError() throws {
+        delegate = nil
+    }
+
+    private func makeTestImage(width: CGFloat = 100, height: CGFloat = 100) -> NSImage {
+        let img = NSImage(size: NSSize(width: width, height: height))
+        img.lockFocus()
+        NSColor.red.setFill()
+        NSRect(origin: .zero, size: img.size).fill()
+        img.unlockFocus()
+        return img
+    }
+
+    func testResizeToSmallDimensions() {
+        let original = makeTestImage(width: 512, height: 512)
+        let resized = delegate.resizeImage(image: original, w: 16, h: 16)
+        XCTAssertEqual(resized.size.width, 16)
+        XCTAssertEqual(resized.size.height, 16)
+    }
+
+    func testResizeToMenuIconSize() {
+        let original = makeTestImage()
+        let resized = delegate.resizeImage(image: original, w: 20, h: 20)
+        XCTAssertEqual(resized.size.width, 20)
+        XCTAssertEqual(resized.size.height, 20)
+    }
+
+    func testResizeToStatusBarIconSize() {
+        let original = makeTestImage()
+        let resized = delegate.resizeImage(image: original, w: 16, h: 16)
+        XCTAssertEqual(resized.size.width, 16)
+        XCTAssertEqual(resized.size.height, 16)
+    }
+
+    func testIsTemplateDefaultFalse() {
+        let original = makeTestImage()
+        let resized = delegate.resizeImage(image: original, w: 20, h: 20)
+        XCTAssertFalse(resized.isTemplate)
+    }
+
+    func testIsTemplateTrue() {
+        let original = makeTestImage()
+        let resized = delegate.resizeImage(image: original, w: 16, h: 16, isTemplate: true)
+        XCTAssertTrue(resized.isTemplate)
+    }
+
+    func testNonSquareResize() {
+        let original = makeTestImage(width: 200, height: 100)
+        let resized = delegate.resizeImage(image: original, w: 40, h: 20)
+        XCTAssertEqual(resized.size.width, 40)
+        XCTAssertEqual(resized.size.height, 20)
+    }
+
+    func testResizeProducesNewImage() {
+        let original = makeTestImage()
+        let resized = delegate.resizeImage(image: original, w: 32, h: 32)
+        XCTAssertFalse(resized === original)
+    }
+
+    func testResizeToSameDimensions() {
+        let original = makeTestImage(width: 20, height: 20)
+        let resized = delegate.resizeImage(image: original, w: 20, h: 20)
+        XCTAssertEqual(resized.size.width, 20)
+        XCTAssertEqual(resized.size.height, 20)
+    }
+}
+
+// MARK: - URL.userHome / URL.userHomePath Tests
+
+final class URLUserHomeTests: XCTestCase {
+
+    func testUserHomePathIsNonEmpty() {
+        XCTAssertFalse(URL.userHomePath.isEmpty)
+    }
+
+    func testUserHomePathIsAbsolute() {
+        XCTAssertTrue(URL.userHomePath.hasPrefix("/"))
+    }
+
+    func testUserHomeIsDirectory() {
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(
+            atPath: URL.userHomePath,
+            isDirectory: &isDirectory
+        )
+        XCTAssertTrue(exists)
+        XCTAssertTrue(isDirectory.boolValue)
+    }
+
+    func testUserHomeURLMatchesPath() {
+        XCTAssertEqual(URL.userHome.path, URL.userHomePath)
+    }
+
+    func testUserHomeURLIsDirectory() {
+        XCTAssertTrue(URL.userHome.hasDirectoryPath)
+    }
+}
+
+// MARK: - DirectoryAccess Tests
+
+final class DirectoryAccessTests: XCTestCase {
+
+    private let testKey = "userSelectedDirectory"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: testKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: testKey)
+        super.tearDown()
+    }
+
+    func testRestoreAccessReturnsNilWhenNoBookmark() {
+        let url = DirectoryAccess.restoreAccess()
+        XCTAssertNil(url)
+    }
+
+    func testRetractAccessRemovesBookmark() {
+        UserDefaults.standard.set(Data([0x01, 0x02]), forKey: testKey)
+        XCTAssertNotNil(UserDefaults.standard.data(forKey: testKey))
+
+        DirectoryAccess.retractAccess()
+
+        XCTAssertNil(UserDefaults.standard.data(forKey: testKey))
+    }
+
+    func testRetractAccessIsIdempotent() {
+        DirectoryAccess.retractAccess()
+        DirectoryAccess.retractAccess()
+        XCTAssertNil(UserDefaults.standard.data(forKey: testKey))
+    }
+
+    func testRestoreAccessWithCorruptBookmarkReturnsNil() {
+        UserDefaults.standard.set(Data([0xDE, 0xAD, 0xBE, 0xEF]), forKey: testKey)
+        let url = DirectoryAccess.restoreAccess()
+        XCTAssertNil(url)
+    }
+}
+
+// MARK: - App Sorting Logic Tests
+
+final class AppSortingTests: XCTestCase {
+
+    private func sortedApps(
+        _ apps: [(String, NSImage?, String)],
+        caseInsensitive: Bool
+    ) -> [(String, NSImage?, String)] {
+        apps.sorted {
+            if caseInsensitive {
+                return $0.0.localizedCaseInsensitiveCompare($1.0) == .orderedAscending
+            } else {
+                return $0.0 < $1.0
+            }
         }
     }
 
+    func testCaseSensitiveSortingPutsUppercaseFirst() {
+        let apps: [(String, NSImage?, String)] = [("mail", nil, ""), ("Xcode", nil, ""), ("safari", nil, "")]
+        let sorted = sortedApps(apps, caseInsensitive: false)
+        // ASCII: uppercase < lowercase → "Xcode" before "mail" and "safari"
+        XCTAssertEqual(sorted.map { $0.0 }, ["Xcode", "mail", "safari"])
+    }
+
+    func testCaseInsensitiveSortingIgnoresCase() {
+        let apps: [(String, NSImage?, String)] = [("mail", nil, ""), ("Xcode", nil, ""), ("Safari", nil, "")]
+        let sorted = sortedApps(apps, caseInsensitive: true)
+        XCTAssertEqual(sorted.map { $0.0 }, ["mail", "Safari", "Xcode"])
+    }
+
+    func testAlreadySortedListIsUnchanged() {
+        let apps: [(String, NSImage?, String)] = [("App A", nil, ""), ("App B", nil, ""), ("App C", nil, "")]
+        let sorted = sortedApps(apps, caseInsensitive: false)
+        XCTAssertEqual(sorted.map { $0.0 }, ["App A", "App B", "App C"])
+    }
+
+    func testReverseOrderedListIsSorted() {
+        let apps: [(String, NSImage?, String)] = [("Zoom", nil, ""), ("Mail", nil, ""), ("Finder", nil, "")]
+        let sorted = sortedApps(apps, caseInsensitive: true)
+        XCTAssertEqual(sorted.map { $0.0 }, ["Finder", "Mail", "Zoom"])
+    }
+
+    func testEmptyListReturnEmpty() {
+        let apps: [(String, NSImage?, String)] = []
+        let sorted = sortedApps(apps, caseInsensitive: false)
+        XCTAssertTrue(sorted.isEmpty)
+    }
+
+    func testSingleElementReturnsSelf() {
+        let apps: [(String, NSImage?, String)] = [("OnlyApp", nil, "/Applications/OnlyApp.app")]
+        let sorted = sortedApps(apps, caseInsensitive: false)
+        XCTAssertEqual(sorted.count, 1)
+        XCTAssertEqual(sorted[0].0, "OnlyApp")
+    }
+
+    func testDuplicateNamesPreservedBothEntries() {
+        let apps: [(String, NSImage?, String)] = [("TextEdit", nil, "/p1"), ("TextEdit", nil, "/p2")]
+        let sorted = sortedApps(apps, caseInsensitive: false)
+        XCTAssertEqual(sorted.count, 2)
+    }
+}
+
+// MARK: - UserDefaults / Settings Keys Tests
+
+final class UserDefaultsSettingsTests: XCTestCase {
+
+    private let keys = ["menuBarOption", "caseInsensitiveAppsSorting",
+                        "listAppsFromSubDirsRecursively", "showChromeApps"]
+
+    override func setUp() {
+        super.setUp()
+        keys.forEach { UserDefaults.standard.removeObject(forKey: $0) }
+    }
+
+    override func tearDown() {
+        keys.forEach { UserDefaults.standard.removeObject(forKey: $0) }
+        super.tearDown()
+    }
+
+    func testMenuBarOptionDefaultsToZero() {
+        XCTAssertEqual(UserDefaults.standard.integer(forKey: "menuBarOption"), 0)
+    }
+
+    func testMenuBarOptionCanBeSetToText() {
+        UserDefaults.standard.set(0, forKey: "menuBarOption")
+        XCTAssertEqual(UserDefaults.standard.integer(forKey: "menuBarOption"), 0)
+    }
+
+    func testMenuBarOptionCanBeSetToIcon() {
+        UserDefaults.standard.set(1, forKey: "menuBarOption")
+        XCTAssertEqual(UserDefaults.standard.integer(forKey: "menuBarOption"), 1)
+    }
+
+    func testMenuBarOptionCanBeSetToTextAndIcon() {
+        UserDefaults.standard.set(2, forKey: "menuBarOption")
+        XCTAssertEqual(UserDefaults.standard.integer(forKey: "menuBarOption"), 2)
+    }
+
+    func testCaseInsensitiveSortingDefaultsFalse() {
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: "caseInsensitiveAppsSorting"))
+    }
+
+    func testShowChromeAppsDefaultsFalse() {
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: "showChromeApps"))
+    }
+
+    func testCaseInsensitiveSortingCanBeEnabled() {
+        UserDefaults.standard.set(true, forKey: "caseInsensitiveAppsSorting")
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "caseInsensitiveAppsSorting"))
+    }
+
+    func testShowChromeAppsCanBeEnabled() {
+        UserDefaults.standard.set(true, forKey: "showChromeApps")
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "showChromeApps"))
+    }
+}
+
+// MARK: - NotificationCenter "MenuOptionChanged" Tests
+
+final class MenuOptionChangedNotificationTests: XCTestCase {
+
+    func testNotificationCanBePosted() {
+        let expectation = XCTestExpectation(description: "MenuOptionChanged notification received")
+        let name = NSNotification.Name("MenuOptionChanged")
+
+        let observer = NotificationCenter.default.addObserver(
+            forName: name,
+            object: nil,
+            queue: .main
+        ) { _ in
+            expectation.fulfill()
+        }
+
+        NotificationCenter.default.post(name: name, object: nil)
+
+        wait(for: [expectation], timeout: 1.0)
+        NotificationCenter.default.removeObserver(observer)
+    }
+
+    func testNotificationNameMatchesExpectedString() {
+        let name = NSNotification.Name("MenuOptionChanged")
+        XCTAssertEqual(name.rawValue, "MenuOptionChanged")
+    }
+
+    func testMultipleObserversAllReceiveNotification() {
+        let exp1 = XCTestExpectation(description: "Observer 1 received notification")
+        let exp2 = XCTestExpectation(description: "Observer 2 received notification")
+        let name = NSNotification.Name("MenuOptionChanged")
+
+        let obs1 = NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { _ in exp1.fulfill() }
+        let obs2 = NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { _ in exp2.fulfill() }
+
+        NotificationCenter.default.post(name: name, object: nil)
+
+        wait(for: [exp1, exp2], timeout: 1.0)
+        NotificationCenter.default.removeObserver(obs1)
+        NotificationCenter.default.removeObserver(obs2)
+    }
+}
+
+// MARK: - fetchAppDetails Tests
+
+final class FetchAppDetailsTests: XCTestCase {
+
+    var delegate: AppDelegate!
+    var tmpDir: URL!
+
+    override func setUpWithError() throws {
+        delegate = AppDelegate()
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tmpDir)
+        delegate = nil
+    }
+
+    private func makeAppBundle(name: String, plist: [String: Any]?) throws -> String {
+        let appPath = tmpDir.appendingPathComponent(name).path
+        let contentsPath = appPath + "/Contents"
+        try FileManager.default.createDirectory(
+            atPath: contentsPath, withIntermediateDirectories: true
+        )
+        if let plist = plist {
+            let plistData = try PropertyListSerialization.data(
+                fromPropertyList: plist,
+                format: .xml,
+                options: 0
+            )
+            try plistData.write(to: URL(fileURLWithPath: contentsPath + "/Info.plist"))
+        }
+        return appPath
+    }
+
+    func testFallsBackToCategoryOtherWhenPlistMissing() throws {
+        let appPath = try makeAppBundle(name: "NoInfo.app", plist: nil)
+        let (category, _, _) = delegate.fetchAppDetails(atPath: appPath)
+        XCTAssertEqual(category, "Other")
+    }
+
+    func testFallsBackToFilenameWhenCFBundleNameMissing() throws {
+        let appPath = try makeAppBundle(name: "My-Cool-App.app", plist: [:])
+        let (_, appName, _) = delegate.fetchAppDetails(atPath: appPath)
+        XCTAssertFalse(appName.isEmpty)
+    }
+
+    func testUsesCFBundleNameFromPlist() throws {
+        let appPath = try makeAppBundle(
+            name: "Dummy.app",
+            plist: [
+                "CFBundleName": "My Great App",
+                "LSApplicationCategoryType": "public.app-category.utilities"
+            ]
+        )
+        let (category, appName, _) = delegate.fetchAppDetails(atPath: appPath)
+        XCTAssertEqual(appName, "My Great App")
+        XCTAssertEqual(category, "public.app-category.utilities")
+    }
+
+    func testUsesCFBundleDisplayNameAsFallback() throws {
+        let appPath = try makeAppBundle(
+            name: "Dummy2.app",
+            plist: ["CFBundleDisplayName": "Display Name App"]
+        )
+        let (_, appName, _) = delegate.fetchAppDetails(atPath: appPath)
+        XCTAssertEqual(appName, "Display Name App")
+    }
+
+    func testEmptyCategoryFallsBackToOther() throws {
+        let appPath = try makeAppBundle(
+            name: "Dummy3.app",
+            plist: ["CFBundleName": "Test", "LSApplicationCategoryType": ""]
+        )
+        let (category, _, _) = delegate.fetchAppDetails(atPath: appPath)
+        XCTAssertEqual(category, "Other")
+    }
+
+    func testIconIsNonNilForValidApp() throws {
+        // fetchAppDetails always falls back to the generic workspace icon
+        let appPath = try makeAppBundle(
+            name: "IconTest.app",
+            plist: ["CFBundleName": "IconTest"]
+        )
+        let (_, _, icon) = delegate.fetchAppDetails(atPath: appPath)
+        XCTAssertNotNil(icon)
+    }
+
+    func testUnknownAppFallbackName() throws {
+        // An entirely missing plist should yield the filename-derived name, not "Unknown App"
+        let appPath = try makeAppBundle(name: "FancyTool.app", plist: nil)
+        let (_, appName, _) = delegate.fetchAppDetails(atPath: appPath)
+        XCTAssertFalse(appName.isEmpty)
+        XCTAssertNotEqual(appName, "Unknown App")
+    }
+}
+
+// MARK: - VersionView helper logic
+
+final class VersionViewLogicTests: XCTestCase {
+
+    private func getAppVersion() -> String {
+        if let version = Bundle.main.infoDictionary?["AppVersion"] as? String {
+            return version
+        }
+        return "Version not found"
+    }
+
+    func testVersionStringIsNonEmpty() {
+        XCTAssertFalse(getAppVersion().isEmpty)
+    }
+
+    func testVersionStringIsEitherRealOrFallback() {
+        let v = getAppVersion()
+        XCTAssertTrue(v.contains(".") || v == "Version not found")
+    }
+}
+
+// MARK: - Performance
+
+final class PerformanceTests: XCTestCase {
+
+    func testMakeHumanReadablePerformance() throws {
+        let delegate = AppDelegate()
+        measure {
+            for _ in 0..<10_000 {
+                _ = delegate.makeHumanReadable("public.app-category.developer-tools")
+            }
+        }
+    }
+
+    func testResizeImagePerformance() throws {
+        let delegate = AppDelegate()
+        let img = NSImage(size: NSSize(width: 512, height: 512))
+        measure {
+            for _ in 0..<200 {
+                _ = delegate.resizeImage(image: img, w: 20, h: 20)
+            }
+        }
+    }
 }

--- a/ApplicationMenuTests/ApplicationMenuTests.swift.bak
+++ b/ApplicationMenuTests/ApplicationMenuTests.swift.bak
@@ -1,0 +1,36 @@
+//
+//  ApplicationMenuTests.swift
+//  ApplicationMenuTests
+//
+//  Created by Artur Barseghyan on 29/01/2024.
+//
+
+import XCTest
+@testable import ApplicationMenu
+
+final class ApplicationMenuTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/ApplicationMenuUITests/ApplicationMenuUITests.swift
+++ b/ApplicationMenuUITests/ApplicationMenuUITests.swift
@@ -9,30 +9,28 @@ import XCTest
 
 final class ApplicationMenuUITests: XCTestCase {
 
+    var app: XCUIApplication!
+
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        app = XCUIApplication()
+        app.launchArguments += ["-AppleLanguages", "(en)"]
+        app.launchArguments += ["-AppleLocale", "en_US"]
     }
 
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        app = nil
     }
 
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
+    // MARK: - Launch
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    func testAppLaunchesWithoutCrash() throws {
+        app.launch()
+        XCTAssertTrue(app.state == .runningForeground || app.state == .runningBackground)
     }
 
     func testLaunchPerformance() throws {
         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // This measures how long it takes to launch your application.
             measure(metrics: [XCTApplicationLaunchMetric()]) {
                 XCUIApplication().launch()
             }

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,17 @@ are used for versioning (schema follows below):
   0.3.4 to 0.4).
 - All backwards incompatible changes are mentioned in this document.
 
+0.1.6
+-----
+2026-04-01
+
+.. note::
+
+    Release is dedicated to my beloved son Raffi, who turned 21 recently.
+
+- Tested on macOS Tahoe.
+- Improve tests and significantly simplify release process.
+
 0.1.5
 -----
 2024-11-06

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,317 @@
+# =============================================================================
+# Makefile — ApplicationMenu
+# =============================================================================
+# All tools (xcodebuild, hdiutil, ditto, codesign, shasum) ship with macOS and
+# Xcode Command Line Tools.  No third-party utilities are required.
+#
+# xcpretty is used when available to format xcodebuild output.  If it is not
+# installed the raw xcodebuild output is shown instead.  Install it with:
+#   gem install xcpretty
+#
+# Quick reference
+# ---------------
+#   make build          Compile Debug build (smoke-check; no artefact saved)
+#   make test           Run unit + UI tests
+#   make test-unit      Run unit tests only (faster)
+#   make archive        Build Release .xcarchive → Releases/archive/
+#   make export         Extract .app from archive → Releases/export/
+#   make dmg            Build installer .dmg     → Releases/dist/
+#   make zip            Wrap .dmg in ZIP          → Releases/dist/
+#   make checksum       Print + save SHA-256      → Releases/dist/
+#   make release        Full pipeline (archive → export → dmg → zip → checksum)
+#   make version        Print current MARKETING_VERSION
+#   make bump V=0.2.0   Set a new version in the project file
+#   make clean          Remove all generated artefacts
+#   make open           Open the project in Xcode
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Project identity
+# ---------------------------------------------------------------------------
+PROJECT   := ApplicationMenu.xcodeproj
+SCHEME    := ApplicationMenu
+APP_NAME  := ApplicationMenu
+
+# macOS destination string used by every xcodebuild invocation
+DEST      := platform=macOS
+
+# ---------------------------------------------------------------------------
+# Output directories  (all under Releases/, which is already in .gitignore)
+# ---------------------------------------------------------------------------
+RELEASES_DIR := Releases
+ARCHIVE_DIR  := $(RELEASES_DIR)/archive
+EXPORT_DIR   := $(RELEASES_DIR)/export
+STAGING_DIR  := $(RELEASES_DIR)/staging
+DIST_DIR     := $(RELEASES_DIR)/dist
+
+# Individual artefact paths
+ARCHIVE_PATH := $(ARCHIVE_DIR)/$(APP_NAME).xcarchive
+APP_PATH     := $(EXPORT_DIR)/$(APP_NAME).app
+DMG_PATH     := $(DIST_DIR)/$(APP_NAME).dmg
+ZIP_PATH     := $(DIST_DIR)/$(APP_NAME).zip
+SHASUM_PATH  := $(DIST_DIR)/$(APP_NAME).zip.sha256
+
+# Temporary exportOptions.plist (written at export time, removed afterwards)
+EXPORT_OPTS  := $(RELEASES_DIR)/.exportOptions.plist
+
+# ---------------------------------------------------------------------------
+# Version (read directly from the project file; no Xcode required)
+# ---------------------------------------------------------------------------
+# Escape dots so the string is safe to use in sed patterns below.
+VERSION     := $(shell grep -m1 'MARKETING_VERSION' $(PROJECT)/project.pbxproj \
+                 | sed 's/.*= //;s/;//')
+VERSION_ESC := $(shell echo "$(VERSION)" | sed 's/\./\\./g')
+
+# ---------------------------------------------------------------------------
+# xcodebuild output filter
+# Use xcpretty when installed; fall back to raw output transparently.
+# ---------------------------------------------------------------------------
+XCPRETTY := $(shell command -v xcpretty 2>/dev/null)
+ifdef XCPRETTY
+  PIPE := | xcpretty
+else
+  PIPE :=
+endif
+
+# ---------------------------------------------------------------------------
+# Phony targets
+# ---------------------------------------------------------------------------
+.PHONY: all build test test-unit archive export dmg zip checksum tap release \
+         version bump open clean help
+
+all: help
+
+# ---------------------------------------------------------------------------
+# Development
+# ---------------------------------------------------------------------------
+
+## build: Compile a Debug build (smoke-check)
+build:
+	xcodebuild build \
+	  -project       "$(PROJECT)" \
+	  -scheme        "$(SCHEME)" \
+	  -configuration Debug \
+	  -destination   "$(DEST)" \
+	  CODE_SIGN_IDENTITY="-" \
+	  $(PIPE)
+
+## test: Run the full test suite (unit + UI tests)
+test:
+	xcodebuild test \
+	  -project       "$(PROJECT)" \
+	  -scheme        "$(SCHEME)" \
+	  -destination   "$(DEST)" \
+	  CODE_SIGN_IDENTITY="-" \
+	  $(PIPE)
+
+## test-unit: Run unit tests only, skipping UI tests (faster)
+test-unit:
+	xcodebuild test \
+	  -project       "$(PROJECT)" \
+	  -scheme        "$(SCHEME)" \
+	  -destination   "$(DEST)" \
+	  -only-testing  "$(APP_NAME)Tests" \
+	  CODE_SIGN_IDENTITY="-" \
+	  $(PIPE)
+
+# ---------------------------------------------------------------------------
+# Release pipeline
+# ---------------------------------------------------------------------------
+
+## archive: Build a Release .xcarchive
+archive:
+	@mkdir -p "$(ARCHIVE_DIR)"
+	xcodebuild archive \
+	  -project      "$(PROJECT)" \
+	  -scheme       "$(SCHEME)" \
+	  -configuration Release \
+	  -archivePath  "$(ARCHIVE_PATH)" \
+	  CODE_SIGN_IDENTITY="-" \
+	  $(PIPE)
+	@echo "→ Archive: $(ARCHIVE_PATH)"
+
+## export: Extract the .app from the archive (equivalent to: Distribute App → Copy App)
+export:
+	@test -d "$(ARCHIVE_PATH)" || \
+	  (echo "No archive found at $(ARCHIVE_PATH). Run 'make archive' first."; exit 1)
+	@mkdir -p "$(EXPORT_DIR)"
+	@# Write a self-contained exportOptions.plist for the "Copy App" method.
+	@# This replicates the manual: Distribute App → Custom → Copy App → Export.
+	@printf '%s\n' \
+	  '<?xml version="1.0" encoding="UTF-8"?>' \
+	  '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' \
+	  '<plist version="1.0">' \
+	  '<dict>' \
+	  '    <key>method</key>' \
+	  '    <string>mac-application</string>' \
+	  '</dict>' \
+	  '</plist>' \
+	  > "$(EXPORT_OPTS)"
+	xcodebuild -exportArchive \
+	  -archivePath        "$(ARCHIVE_PATH)" \
+	  -exportPath         "$(EXPORT_DIR)" \
+	  -exportOptionsPlist "$(EXPORT_OPTS)" \
+	  $(PIPE)
+	@rm -f "$(EXPORT_OPTS)"
+	@echo "→ App: $(APP_PATH)"
+
+## dmg: Build the installer .dmg  (equivalent to: create ApplicationMenuInstaller + hdiutil)
+#
+# The staging directory mirrors what was previously assembled by hand:
+#   ApplicationMenuInstaller/
+#     ApplicationMenu.app          ← the exported app
+#     Applications                 ← symlink to /Applications  (replaces the
+#                                     Finder "Make Alias" step; a symlink inside
+#                                     a .dmg behaves identically to a Finder alias
+#                                     for drag-install purposes)
+dmg:
+	@test -d "$(APP_PATH)" || \
+	  (echo "No .app found at $(APP_PATH). Run 'make export' first."; exit 1)
+	@mkdir -p "$(STAGING_DIR)" "$(DIST_DIR)"
+	@rm -rf "$(STAGING_DIR)/$(APP_NAME).app" "$(STAGING_DIR)/Applications"
+	ditto "$(APP_PATH)" "$(STAGING_DIR)/$(APP_NAME).app"
+	@ln -sf /Applications "$(STAGING_DIR)/Applications"
+	hdiutil create \
+	  -volname   "$(APP_NAME)" \
+	  -srcfolder "$(STAGING_DIR)" \
+	  -ov \
+	  -format    UDZO \
+	  "$(DMG_PATH)"
+	@echo "→ DMG: $(DMG_PATH)"
+
+## zip: Wrap the .dmg in a ZIP archive (required format for the Homebrew cask)
+zip:
+	@test -f "$(DMG_PATH)" || \
+	  (echo "No .dmg found at $(DMG_PATH). Run 'make dmg' first."; exit 1)
+	@mkdir -p "$(DIST_DIR)"
+	@# ditto -ck produces a macOS-native ZIP with no resource-fork noise.
+	@# The result is a ZIP containing just ApplicationMenu.dmg at its root,
+	@# which is the format the tap formula (and GitHub releases) expect.
+	ditto -ck "$(DMG_PATH)" "$(ZIP_PATH)"
+	@echo "→ ZIP: $(ZIP_PATH)"
+
+## checksum: Compute and save the SHA-256 of the ZIP (paste into the tap formula)
+checksum:
+	@test -f "$(ZIP_PATH)" || \
+	  (echo "No ZIP found at $(ZIP_PATH). Run 'make zip' first."; exit 1)
+	@shasum -a 256 "$(ZIP_PATH)" | tee "$(SHASUM_PATH)"
+	@echo "→ Checksum saved: $(SHASUM_PATH)"
+
+## tap: Generate Homebrew tap cask files → Releases/tap/
+tap: checksum
+	@mkdir -p "$(RELEASES_DIR)/tap"
+	@SHA256=$$(awk '{print $$1}' "$(SHASUM_PATH)") && \
+	( \
+	  echo 'cask "app-menu" do' ; \
+	  echo "  version \"$(VERSION)\"" ; \
+	  echo "  sha256 \"$$SHA256\"" ; \
+	  echo '' ; \
+	  echo "  url \"https://github.com/barseghyanartur/app-menu/releases/download/$(VERSION)/ApplicationMenu.zip\"" ; \
+	  echo '  name "App Menu"' ; \
+	  echo '  desc "The missing Applications Menu for macOS."' ; \
+	  echo '  homepage "https://github.com/barseghyanartur/app-menu"' ; \
+	  echo '' ; \
+	  echo '  container type: :naked' ; \
+	  echo '' ; \
+	  echo '  stage_only true' ; \
+	  echo '' ; \
+	  echo '  postflight do' ; \
+	  echo '    zip_path = "#{staged_path}/ApplicationMenu.zip"' ; \
+	  echo '    extract_dir = "#{staged_path}/extracted"' ; \
+	  echo '' ; \
+	  echo '    system_command "unzip", args: ["-d", extract_dir, zip_path]' ; \
+	  echo '' ; \
+	  echo '    dmg_path = "#{extract_dir}/ApplicationMenu.dmg"' ; \
+	  echo '' ; \
+	  echo '    if File.exist?(dmg_path)' ; \
+	  echo '      system_command "hdiutil",' ; \
+	  echo '                     args: ["attach", "-nobrowse", dmg_path]' ; \
+	  echo '' ; \
+	  echo '      if File.exist?("/Applications/ApplicationMenu.app")' ; \
+	  echo '        system_command "rm", args: ["-rf", "/Applications/ApplicationMenu.app"]' ; \
+	  echo '      end' ; \
+	  echo '' ; \
+	  echo '      system_command "cp", ' ; \
+	  echo '                     args: ["-r", "/Volumes/ApplicationMenu/ApplicationMenu.app", "/Applications/"]' ; \
+	  echo '' ; \
+	  echo '      system_command "hdiutil",' ; \
+	  echo '                     args: ["detach", "/Volumes/ApplicationMenu"]' ; \
+	  echo '    else' ; \
+	  echo '      raise "DMG file not found: #{dmg_path}"' ; \
+	  echo '    end' ; \
+	  echo '  end' ; \
+	  echo '' ; \
+	  echo '  uninstall delete: "/Applications/ApplicationMenu.app"' ; \
+	  echo 'end' \
+	) > "$(RELEASES_DIR)/tap/app-menu.rb" && \
+	sed "s/app-menu\" do/app-menu@$(VERSION)\" do/" "$(RELEASES_DIR)/tap/app-menu.rb" > "$(RELEASES_DIR)/tap/app-menu@$(VERSION).rb" && \
+	echo "→ Tap files: $(RELEASES_DIR)/tap/"
+
+## release: Full pipeline — archive → export → dmg → zip → checksum → tap
+release: archive export dmg zip checksum tap
+	@echo ""
+	@echo "╔══════════════════════════════════════════════════════╗"
+	@echo "║  Release artefacts ready — v$(VERSION)"
+	@echo "╠══════════════════════════════════════════════════════╣"
+	@echo "║  Archive  : $(ARCHIVE_PATH)"
+	@echo "║  App      : $(APP_PATH)"
+	@echo "║  DMG      : $(DMG_PATH)"
+	@echo "║  ZIP      : $(ZIP_PATH)"
+	@echo "║  SHA-256  : $$(awk '{print $$1}' $(SHASUM_PATH))"
+	@echo "║  Tap      : $(RELEASES_DIR)/tap/app-menu.rb"
+	@echo "║            $(RELEASES_DIR)/tap/app-menu@$(VERSION).rb"
+	@echo "╠══════════════════════════════════════════════════════╣"
+	@echo "║  Next steps:"
+	@echo "║  1. git tag $(VERSION) && git push --tags"
+	@echo "║  2. Upload $(APP_NAME).zip to the GitHub release"
+	@echo "║  3. Copy tap files to your Homebrew tap repo:"
+	@echo "║       cp Releases/tap/*.rb /path/to/your-tap/Casks/"
+	@echo "╚══════════════════════════════════════════════════════╝"
+
+# ---------------------------------------------------------------------------
+# Utility
+# ---------------------------------------------------------------------------
+
+## version: Print the current MARKETING_VERSION
+version:
+	@echo $(VERSION)
+
+## bump V=x.y.z: Set a new MARKETING_VERSION in the Xcode project file
+#
+# Usage: make bump V=0.2.0
+#
+# Only MARKETING_VERSION lines are touched; CURRENT_PROJECT_VERSION (the
+# integer build number) is left unchanged.
+bump:
+	@test -n "$(V)" || { echo "Usage: make bump V=<new.version>  e.g. make bump V=0.2.0"; exit 1; }
+	@grep -q "MARKETING_VERSION = $(VERSION_ESC);" "$(PROJECT)/project.pbxproj" || \
+	  { echo "Current version '$(VERSION)' not found in project file."; exit 1; }
+	@sed -i '' \
+	  "s/MARKETING_VERSION = $(VERSION_ESC);/MARKETING_VERSION = $(V);/g" \
+	  "$(PROJECT)/project.pbxproj"
+	@echo "Bumped: $(VERSION) → $(V)"
+	@echo "Remember to add an entry to CHANGELOG.rst before committing."
+
+## open: Open the project in Xcode
+open:
+	open "$(PROJECT)"
+
+## clean: Remove all generated artefacts (the Releases/ directory)
+clean:
+	@rm -rf "$(RELEASES_DIR)"
+	@echo "Removed $(RELEASES_DIR)/"
+
+# ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+
+## help: List available targets
+help:
+	@echo ""
+	@echo "Usage: make <target>  [V=<version> for bump]"
+	@echo ""
+	@awk '/^## /{sub(/^## /,""); n=index($$0,": "); printf "  \033[36m%-14s\033[0m %s\n", substr($$0,1,n-1), substr($$0,n+2)}' \
+	  $(MAKEFILE_LIST)
+	@echo ""
+	@echo "  Current version: $(VERSION)"
+	@echo ""

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,14 @@ app-menu
 
 .. _tabler icons: https://github.com/tabler/tabler-icons
 
+.. image:: https://github.com/barseghyanartur/app-menu/actions/workflows/test.yml/badge.svg?branch=main
+   :target: https://github.com/barseghyanartur/app-menu/actions
+   :alt: Build Status
+
+.. image:: https://img.shields.io/badge/license-MIT-blue.svg
+   :target: https://github.com/barseghyanartur/app-menu/#Licence
+   :alt: MIT
+
 The missing Applications Menu for macOS.
 
 .. image:: Docs/app_menu_screenshot.jpg
@@ -17,6 +25,7 @@ The missing Applications Menu for macOS.
 
 Compatibility
 =============
+- macOS Tahoe (26.x)
 - macOS Sequoia (15.x)
 - macOS Sanoma (14.x)
 - macOS Ventura (13.x)

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -8,7 +8,7 @@ Archive the application
 #. Xcode -> Product -> Archive : Distribute App -> Custom -> Copy App : Export
 #. Create another directory `ApplicationMenuInstaller` in the directory where your `ApplicationMenu.app` was created.
 #. Move the `ApplicationMenu.app` into that directory.
-#. Create an alias from `/Applications` directory: Finder -> Macintosch HD -> `Ctrl + Click` on the `Applications` -> Make Alias.
+#. Create an alias from `/Applications` directory: Finder -> Macintosh HD -> `Ctrl + Click` on the `Applications` -> Make Alias.
 #. Move the created alias from `/Users/me/Desktop` into `ApplicationMenuInstaller`.
 #. Create a dmg archive:
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,27 @@
+==========================
+How to release a macOs app
+==========================
+
+Archive the application
+=======================
+#. Xcode -> Product -> Build
+#. Xcode -> Product -> Archive : Distribute App -> Custom -> Copy App : Export
+#. Create another directory `ApplicationMenuInstaller` in the directory where your `ApplicationMenu.app` was created.
+#. Move the `ApplicationMenu.app` into that directory.
+#. Create an alias from `/Applications` directory: Finder -> Macintosch HD -> `Ctrl + Click` on the `Applications` -> Make Alias.
+#. Move the created alias from `/Users/me/Desktop` into `ApplicationMenuInstaller`.
+#. Create a dmg archive:
+
+   .. code-block:: sh
+
+	  hdiutil create -volname "ApplicationMenu" -srcfolder ApplicationMenuInstaller -ov -format UDZO ApplicationMenu.dmg
+
+#. Pack the `ApplicationMenu.dmg` into a ZIP archive (using `Double Commander`).
+
+Calculate shasum for tap
+========================
+#. Calculate the shasum for the `ApplicationMenu.zip` archive:
+
+   .. code-block:: sh
+   
+       shasum -a 256 ApplicationMenu.zip

--- a/TESTING.md
+++ b/TESTING.md
@@ -85,6 +85,7 @@ Verifies the keys and default values used throughout the app.
 | `menuBarOption` | `0` (Text) |
 | `caseInsensitiveAppsSorting` | `false` |
 | `showChromeApps` | `false` |
+| `listAppsFromSubDirsRecursively` | `false` |
 
 ### `MenuOptionChangedNotificationTests`
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,160 @@
+# Testing Guide — ApplicationMenu
+
+## Overview
+
+The test suite lives in `ApplicationMenuTests/ApplicationMenuTests.swift` and covers all
+pure-logic and side-effect-free code that can be exercised without a running macOS menu bar.
+UI tests in `ApplicationMenuUITests/` cover basic launch behaviour.
+
+---
+
+## Test Classes
+
+### `MakeHumanReadableTests`
+
+Exercises `AppDelegate.makeHumanReadable(_:)`.
+
+| What is tested | Example |
+|---|---|
+| Standard reverse-DNS category → readable title | `"public.app-category.utilities"` → `"Utilities"` |
+| Hyphen-separated words are split and capitalised | `"developer-tools"` → `"Developer Tools"` |
+| Multiple hyphens | `"healthcare-fitness"` → `"Healthcare Fitness"` |
+| Edge cases: empty string, no dots, already capitalised, all-caps | — |
+
+### `MakeHumanReadableFromFilenameTests`
+
+Exercises `AppDelegate.makeHumanReadableFromFilename(_:)`.
+
+| What is tested | Example |
+|---|---|
+| Hyphen-separated → title-cased words | `"google-chrome"` → `"Google Chrome"` |
+| Underscore-separated | `"visual_studio"` → `"Visual Studio"` |
+| Mixed separators | `"my-cool_app"` → `"My Cool App"` |
+| Single word, empty string | — |
+
+### `ResizeImageTests`
+
+Exercises `AppDelegate.resizeImage(image:w:h:isTemplate:)`.
+
+| What is tested |
+|---|
+| Output dimensions match requested `w` × `h` |
+| `isTemplate` defaults to `false`, can be set `true` |
+| Non-square resize |
+| Returns a new `NSImage` instance (not the same object) |
+
+### `URLUserHomeTests`
+
+Exercises the `URL.userHome` / `URL.userHomePath` extension.
+
+| What is tested |
+|---|
+| Path is non-empty and absolute |
+| Path points to an existing directory |
+| `URL.userHome.path` equals `URL.userHomePath` |
+
+### `DirectoryAccessTests`
+
+Exercises `DirectoryAccess.restoreAccess()` and `DirectoryAccess.retractAccess()`.
+
+| What is tested |
+|---|
+| `restoreAccess()` returns `nil` when no bookmark is stored |
+| `retractAccess()` removes the `userSelectedDirectory` key |
+| `retractAccess()` is idempotent |
+| Corrupt bookmark data → `restoreAccess()` returns `nil` (error path) |
+
+### `AppSortingTests`
+
+Exercises the sorting comparator used in `AppDelegate.populateMenu()`.
+
+| What is tested |
+|---|
+| Case-sensitive sort puts uppercase names first |
+| Case-insensitive sort orders alphabetically regardless of case |
+| Already-sorted list is unchanged |
+| Reverse-ordered list is sorted correctly |
+| Empty list, single element, duplicate names |
+
+### `UserDefaultsSettingsTests`
+
+Verifies the keys and default values used throughout the app.
+
+| Key | Default |
+|---|---|
+| `menuBarOption` | `0` (Text) |
+| `caseInsensitiveAppsSorting` | `false` |
+| `showChromeApps` | `false` |
+
+### `MenuOptionChangedNotificationTests`
+
+Verifies the `"MenuOptionChanged"` `NotificationCenter` contract.
+
+| What is tested |
+|---|
+| Notification is received by a registered observer |
+| Multiple observers all receive the same post |
+| `rawValue` equals the expected string |
+
+### `FetchAppDetailsTests`
+
+Exercises `AppDelegate.fetchAppDetails(atPath:)` using temporary `.app` bundles
+constructed on disk.
+
+| What is tested |
+|---|
+| Missing `Info.plist` → category defaults to `"Other"` |
+| Missing `CFBundleName` → name derived from filename |
+| `CFBundleName` is used when present |
+| `CFBundleDisplayName` used as fallback |
+| Empty `LSApplicationCategoryType` → `"Other"` |
+| Icon is never `nil` (falls back to workspace generic icon) |
+
+### `VersionViewLogicTests`
+
+Replicates the `VersionView.getAppVersion()` helper.
+
+| What is tested |
+|---|
+| Result is non-empty |
+| Result is either a semver string or the sentinel `"Version not found"` |
+
+### `PerformanceTests`
+
+Baseline performance measurements (XCTest `measure` blocks).
+
+| What is measured |
+|---|
+| `makeHumanReadable` — 10 000 calls |
+| `resizeImage` — 200 calls with a 512 × 512 source |
+
+---
+
+## Running the Tests
+
+### In Xcode
+
+1. Open `ApplicationMenu.xcodeproj`.
+2. Select the `ApplicationMenuTests` scheme.
+3. Press **⌘U** (or **Product → Test**).
+
+### From the command line
+
+```bash
+xcodebuild test \
+  -project ApplicationMenu.xcodeproj \
+  -scheme ApplicationMenu \
+  -destination 'platform=macOS'
+```
+
+---
+
+## Notes
+
+* Tests that construct temporary `.app` bundles (in `FetchAppDetailsTests`) create files
+  under `FileManager.default.temporaryDirectory` and clean up after each test.
+* `DirectoryAccessTests` clears `UserDefaults.standard["userSelectedDirectory"]` before
+  and after each test to avoid cross-test contamination.
+* `UserDefaultsSettingsTests` similarly isolates all four settings keys.
+* All tests are synchronous except `MenuOptionChangedNotificationTests`, which uses
+  `XCTestExpectation` with a 1-second timeout.


### PR DESCRIPTION
* Add more tests
* Mention tahoe
* Remove macos-13 from GitHub CI due to deprecation
* Tap simplification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped app version to 0.1.6
  * Added automated CI testing workflow and macOS runner coverage
  * Introduced build/release automation for packaging and distribution

* **Tests**
  * Expanded test suite with broad unit and image/filesystem coverage
  * Added UI launch verification and performance benchmarks

* **Documentation**
  * Added testing guide, release procedure, and agent repository docs
  * Updated README with status badge and macOS Tahoe support
* **Changelog**
  * Added 0.1.6 release entry
<!-- end of auto-generated comment: release notes by coderabbit.ai -->